### PR TITLE
Report tweaks

### DIFF
--- a/src/pelagos_py/pipeline.py
+++ b/src/pelagos_py/pipeline.py
@@ -403,21 +403,25 @@ class Pipeline(ConfigMirrorMixin):
         # in the background (regardless of that step's own diagnostics setting)
         # so they can be embedded in the report. This exercises every step's
         # diagnostic code, which is why it can slow the run down.
-        report_present = any(s["name"] == REPORT_STEP_NAME for s in self.steps)
-        if report_present:
-            params = next(s["parameters"] for s in self.steps if s["name"] == "Write Data Report (Python)")
-
-            # Load report settings and see if the user wants to capture diagnostics. If not, don't save the figures in memory.
-            # Debugging pdb.trace() unreliable if _capture_diagnostics turned on.
-            if params.get("show_diagnostic_plots") == True:
-                self._capture_diagnostics = True
-                self._captured_figures = []
-                self._capture_dir = tempfile.mkdtemp(prefix="pelagos_report_diag_")
-                self.logger.warning(
-                    "A report step is enabled: diagnostic plots will be generated in "
-                    "the background for every step that produces one, so the pipeline "
-                    "may run more slowly than usual."
-                )
+        report_params = next(
+            (s["parameters"] for s in self.steps if s["name"] == REPORT_STEP_NAME),
+            None,
+        )
+        report_present = report_params is not None
+        capture_diagnostics = report_present and report_params.get("show_diagnostic_plots", True)
+        
+        # Load report settings and see if the user wants to capture diagnostics. If not, don't save the figures in memory.
+        # Debugging pdb.trace() unreliable if _capture_diagnostics turned on.
+        if capture_diagnostics:
+            self._capture_diagnostics = True
+            self._captured_figures = []
+            self._capture_dir = tempfile.mkdtemp(prefix="pelagos_report_diag_")
+            self.logger.warning(
+                "A report step is enabled: diagnostic plots will be generated in "
+                "the background for every step that produces one, so the pipeline "
+                "may run more slowly than usual. `pdb.trace()` may not work as "
+                "intended."
+            )
 
         # When capturing for the report, force the headless Agg backend once for
         # the whole run (see force_headless_backend). Toggling the backend per
@@ -432,12 +436,10 @@ class Pipeline(ConfigMirrorMixin):
                 for step in self.steps:
                     self._context = self.execute_step(step, self._context)
         finally:
-            if report_present:
-                #   Figures have been embedded by the report writer by now.
-                params = next(s["parameters"] for s in self.steps if s["name"] == "Write Data Report (Python)")
-                if params.get("show_diagnostic_plots") == True:
-                    shutil.rmtree(self._capture_dir, ignore_errors=True)
-                    self._capture_diagnostics = False
+            #   Figures have been embedded by the report writer by now.
+            if capture_diagnostics:
+                shutil.rmtree(self._capture_dir, ignore_errors=True)
+                self._capture_diagnostics = False
 
     def generate_config(self):
         """

--- a/src/pelagos_py/pipeline.py
+++ b/src/pelagos_py/pipeline.py
@@ -434,8 +434,10 @@ class Pipeline(ConfigMirrorMixin):
         finally:
             if report_present:
                 #   Figures have been embedded by the report writer by now.
-                shutil.rmtree(self._capture_dir, ignore_errors=True)
-                self._capture_diagnostics = False
+                params = next(s["parameters"] for s in self.steps if s["name"] == "Write Data Report (Python)")
+                if params.get("show_diagnostic_plots") == True:
+                    shutil.rmtree(self._capture_dir, ignore_errors=True)
+                    self._capture_diagnostics = False
 
     def generate_config(self):
         """

--- a/src/pelagos_py/pipeline.py
+++ b/src/pelagos_py/pipeline.py
@@ -405,15 +405,19 @@ class Pipeline(ConfigMirrorMixin):
         # diagnostic code, which is why it can slow the run down.
         report_present = any(s["name"] == REPORT_STEP_NAME for s in self.steps)
         if report_present:
-            #   TODO: Load report settings and see if the user wants to capture diagnostics. If not, don't save the figures in memory.
-            # self._capture_diagnostics = True
-            self._captured_figures = []
-            self._capture_dir = tempfile.mkdtemp(prefix="pelagos_report_diag_")
-            self.logger.warning(
-                "A report step is enabled: diagnostic plots will be generated in "
-                "the background for every step that produces one, so the pipeline "
-                "may run more slowly than usual."
-            )
+            params = next(s["parameters"] for s in self.steps if s["name"] == "Write Data Report (Python)")
+
+            # Load report settings and see if the user wants to capture diagnostics. If not, don't save the figures in memory.
+            # Debugging pdb.trace() unreliable if _capture_diagnostics turned on.
+            if params.get("show_diagnostic_plots") == True:
+                self._capture_diagnostics = True
+                self._captured_figures = []
+                self._capture_dir = tempfile.mkdtemp(prefix="pelagos_report_diag_")
+                self.logger.warning(
+                    "A report step is enabled: diagnostic plots will be generated in "
+                    "the background for every step that produces one, so the pipeline "
+                    "may run more slowly than usual."
+                )
 
         # When capturing for the report, force the headless Agg backend once for
         # the whole run (see force_headless_backend). Toggling the backend per

--- a/src/pelagos_py/pipeline.py
+++ b/src/pelagos_py/pipeline.py
@@ -405,7 +405,8 @@ class Pipeline(ConfigMirrorMixin):
         # diagnostic code, which is why it can slow the run down.
         report_present = any(s["name"] == REPORT_STEP_NAME for s in self.steps)
         if report_present:
-            self._capture_diagnostics = True
+            #   TODO: Load report settings and see if the user wants to capture diagnostics. If not, don't save the figures in memory.
+            # self._capture_diagnostics = True
             self._captured_figures = []
             self._capture_dir = tempfile.mkdtemp(prefix="pelagos_report_diag_")
             self.logger.warning(

--- a/src/pelagos_py/steps/input_output/write_report_python.py
+++ b/src/pelagos_py/steps/input_output/write_report_python.py
@@ -318,6 +318,7 @@ class ReportPDF(FPDF):
         pipeline_name=None,
         pipeline_description=None,
         track_map_path=None,
+        logo=None,
     ):
         super().__init__(orientation="P", unit="mm", format="A4")
         self.report_title = title
@@ -326,6 +327,7 @@ class ReportPDF(FPDF):
         self.pipeline_name = pipeline_name
         self.pipeline_description = pipeline_description
         self.track_map_path = track_map_path
+        self.logo = logo
         #   A roomy bottom margin keeps body content clear of the page-number
         #   footer (which sits ~15 mm from the foot).
         self.set_auto_page_break(auto=True, margin=20)
@@ -358,16 +360,17 @@ class ReportPDF(FPDF):
         #   Centred title page (title, subtitle, steps, date). The report uses the
         #   Times core font throughout for a traditional, LaTeX-like look.
         self.add_page()
-
         #   NOC logo, centred near the top. Kept small to leave room for the
         #   title-page track map below.
         self.ln(16)
-        logo_w = 20
-        if os.path.exists(LOGO_PATH):
+        logo_w = 20 #   TODO: Make user-configurable
+        
+        if os.path.exists(self.logo):
             try:
-                self.image(LOGO_PATH, x=(self.w - logo_w) / 2, w=logo_w)
+                self.image(self.logo, x=(self.w - logo_w) / 2, w=logo_w)
                 self.ln(logo_w + 6)
             except Exception:  # noqa: BLE001 - logo is decorative, never fatal
+                print(f"Report generation: Logo: Logo path does not exist: {self.logo}")
                 self.ln(16)
         else:
             self.ln(16)
@@ -1065,55 +1068,58 @@ _MAP_START = "#9fe0a0"
 #   LinearSegmentedColormap. ``special`` flags BBP, which is drawn largest-on-top
 #   with smaller markers so its sharp spikes surface rather than hide behind
 #   ordinary points.
+
+try:
+    #   Add stops that are based on cmocean. Total of 10 stops.
+    import cmocean
+    import matplotlib.colors as mcolors
+    def sample_cmap(cmap, n=10):
+        return [mcolors.to_hex(c) for c in cmap(np.linspace(0, 1, n))]
+    temp_stops = sample_cmap(cmocean.cm.thermal)
+    sal_stops = sample_cmap(cmocean.cm.haline)
+    dens_stops = sample_cmap(cmocean.cm.dense)
+    oxy_stops = sample_cmap(cmocean.cm.oxy)
+    chl_stops = sample_cmap(cmocean.cm.algae)
+    bbp_stops = sample_cmap(cmocean.cm.turbid)
+except ImportError:
+    temp_stops = ["#1b1c6e", "#365292", "#5286b7", "#8db4c4", "#dbe5cd", "#f1d8b4", "#d9997e", "#c05e4c", "#a0372b", "#811910",]
+    sal_stops = ["#f9e8b1", "#f1c38f", "#e8a074", "#db7c5f", "#cb5c58","#b2425c", "#943061", "#732460", "#511c53", "#321340",]
+    dens_stops = ["#e6f1f7", "#c4d8e8", "#a6bed9", "#8ba4c9", "#7489b8", "#636c9f","#595388", "#55406e", "#4e3055", "#3f2040", "#2e1226",]
+    oxy_stops = ["#400000", "#5c0000", "#780000", "#808080", "#8c8c8c", "#979797","#a3a3a3", "#aeaeae", "#baba10", "#dbdb0a", "#fdfd00",]
+    chl_stops = ["#182548", "#2c5398", "#4a88a4", "#87b8b5", "#dae4da","#e6d992", "#a8ab3e", "#56872e", "#285932", "#1b2617",]
+    bbp_stops = ["#cccccc", "#737373", "#000000", "#1335f5", "#3f8df7","#67dffb", "#a1fc4e", "#f8d748", "#ef8733", "#ea3323",]
+
 _CROSS_SECTION_PANELS = (
     {
         "label": "Temperature",
         "candidates": ("TEMP", "TEMPERATURE", "temp"),
-        "stops": [
-            "#1b1c6e", "#365292", "#5286b7", "#8db4c4", "#dbe5cd",
-            "#f1d8b4", "#d9997e", "#c05e4c", "#a0372b", "#811910",
-        ],
+        "stops": temp_stops,
     },
     {
         "label": "Salinity",
         "candidates": ("PRAC_SALINITY", "ABS_SALINITY", "PSAL", "SALINITY", "salinity"),
-        "stops": [
-            "#f9e8b1", "#f1c38f", "#e8a074", "#db7c5f", "#cb5c58",
-            "#b2425c", "#943061", "#732460", "#511c53", "#321340",
-        ],
+        "stops": sal_stops,
     },
     {
         "label": "Density",
         "candidates": ("DENSITY", "density", "SIGMA0", "SIGMA_THETA", "POTDENS"),
-        "stops": [
-            "#e6f1f7", "#c4d8e8", "#a6bed9", "#8ba4c9", "#7489b8", "#636c9f",
-            "#595388", "#55406e", "#4e3055", "#3f2040", "#2e1226",
-        ],
+        "stops": dens_stops,
     },
     {
         "label": "Oxygen",
         "candidates": ("MOLAR_DOXY", "molar_doxy", "DOXY", "molar_deoxy"),
-        "stops": [
-            "#400000", "#5c0000", "#780000", "#808080", "#8c8c8c", "#979797",
-            "#a3a3a3", "#aeaeae", "#baba10", "#dbdb0a", "#fdfd00",
-        ],
+        "stops": oxy_stops,
     },
     {
         "label": "Chlorophyll",
         "candidates": ("CHLA_ADJUSTED", "CHLA", "chla_adjusted", "CHLOROPHYLL"),
-        "stops": [
-            "#182548", "#2c5398", "#4a88a4", "#87b8b5", "#dae4da",
-            "#e6d992", "#a8ab3e", "#56872e", "#285932", "#1b2617",
-        ],
+        "stops": chl_stops,
     },
     {
         "label": "Backscatter",
         "candidates": ("BBP700", "BBP532", "BBP", "bbp"),
         "special": "bbp",
-        "stops": [
-            "#cccccc", "#737373", "#000000", "#1335f5", "#3f8df7",
-            "#67dffb", "#a1fc4e", "#f8d748", "#ef8733", "#ea3323",
-        ],
+        "stops": bbp_stops,
     },
 )
 
@@ -1378,6 +1384,7 @@ def make_plots(
         and var[:-3] in data.data_vars
         and np.issubdtype(data[var[:-3]].dtype, np.number)
     ]
+    qc_vars.sort()  #   Alphabetize QC plots by variable
 
     #   Only label the plots with the dataset ID when a real one is present; the
     #   placeholder set upstream for files without one should not be shown.
@@ -1705,6 +1712,14 @@ class WriteDataReportPython(BaseStep):
                 "variable index and glider information."
             ),
         },
+        "logo": {
+            "type": str,
+            "default": str(LOGO_PATH),
+            "description": (
+                "Path to where the organization/institution logo is for use "
+                "on the front page."
+            )
+        }
     }
 
     def run(self) -> xr.DataArray:
@@ -1712,7 +1727,6 @@ class WriteDataReportPython(BaseStep):
         odir = self.context["global_parameters"]["out_directory"]
         data = self.context.get("data")
         fname_core = self.context["global_parameters"]["filename_core"]
-
         #   Handle optional parameters
         fname = self.parameters.get("fname")
         if not fname:
@@ -1724,6 +1738,8 @@ class WriteDataReportPython(BaseStep):
         title = self.parameters.get("title")
         if not title:
             title = f"Data report {fname_core.replace('_', ' ')}"
+
+        logo = self.parameters.get("logo")
 
         #   Only show the dataset ID subtitle when one is actually present.
         has_dataset_id = bool(data.attrs.get("dataset_id"))
@@ -1773,6 +1789,7 @@ class WriteDataReportPython(BaseStep):
                 pipeline_name=glob_params.get("name"),
                 pipeline_description=glob_params.get("description"),
                 track_map_path=track_map_path,
+                logo=logo,
             )
             pdf.title_page()
 

--- a/src/pelagos_py/steps/input_output/write_report_python.py
+++ b/src/pelagos_py/steps/input_output/write_report_python.py
@@ -1580,6 +1580,70 @@ def glidertest_section(pdf: ReportPDF, data: xr.Dataset, outdir: str) -> None:
     from glidertest import summary_sheet as gss
     from glidertest import plots as gtplots
 
+    #   TODO: Modularize this with extra config?
+    pdf.add_page()
+    pdf.section_heading("Glidertest Plots: Basic Variables")
+
+    data["PSAL"] = data["PRAC_SALINITY"]
+
+    fig, __ = gtplots.plot_basic_vars(ds=data)
+    fig_name = f"{outdir}_basic_vars.png"
+    fig.savefig(fig_name)
+    pdf.image_fit(
+        fig_name,
+        aspect=_image_aspect(fig_name),
+        max_h=100
+    )
+
+    pdf.add_page()
+    pdf.section_heading("Glidertest Plots: Up/Down bias")
+
+    for var in ["TEMP", "CNDC", "DOXY"]:
+        fig, __ = gtplots.plot_updown_bias(data, var=var)
+        fig_name = f"{outdir}{var}_updown.png"
+        fig.savefig(fig_name)
+        pdf.image_fit(
+            fig_name,
+            aspect=_image_aspect(fig_name),
+            max_h=100,
+        )
+
+    pdf.add_page()
+    pdf.section_heading("Glidertest Plots: Optics assessment")
+
+    #   This step has an output - capture it
+    fig, __ = gtplots.process_optics_assess(ds=data)
+    fig_name = f"{outdir}_optics_assess.png"
+    fig.savefig(fig_name)
+    pdf.image_fit(
+        fig_name,
+        aspect=_image_aspect(fig_name),
+        max_h=100
+    )
+
+    pdf.add_page()
+    pdf.section_heading("Glidertest Plots: Day/night")
+
+    #   Long run duration
+    data = data.set_coords("TIME")
+    # fig, __ = gtplots.plot_daynight_avg(ds=data, var="CNDC")
+    # fig_name = f"{outdir}_daynight_avg_sal.png"
+    # fig.savefig(fig_name)
+    # pdf.image_fit(
+    #     fig_name,
+    #     aspect=_image_aspect(fig_name),
+    #     max_h=100
+    # )
+
+    fig, __ = gtplots.plot_daynight_avg(ds=data, var="CHLA")
+    fig_name = f"{outdir}_daynight_avg_sal.png"
+    fig.savefig(fig_name)
+    pdf.image_fit(
+        fig_name,
+        aspect=_image_aspect(fig_name),
+        max_h=100
+    )
+
     pdf.add_page()
     pdf.section_heading("Glidertest Plots: Hysteresis diagnostics")
 
@@ -1591,7 +1655,8 @@ def glidertest_section(pdf: ReportPDF, data: xr.Dataset, outdir: str) -> None:
             max_h=100,
         )
 
-    # breakpoint()
+    pdf.add_page()
+    pdf.section_heading("Glidertest Plots: Drift plots")
     gss.create_drift_plots(data, path=outdir)
     for fig_name in sorted(glob.glob(os.path.join(outdir, "*_drift.png"))):
         pdf.image_fit(
@@ -1600,18 +1665,6 @@ def glidertest_section(pdf: ReportPDF, data: xr.Dataset, outdir: str) -> None:
             max_h=100,
         )
 
-    path = outdir
-    # breakpoint()
-    for var in ["TEMP", "CNDC", "DOXY"]:
-        fig, ax = gtplots.plot_updown_bias(data, var=var)
-        fig_name = f"{path}/{var}_updown.png"
-        fig.savefig(fig_name)
-        # breakpoint()
-        pdf.image_fit(
-            fig_name,
-            aspect=_image_aspect(fig_name),
-            max_h=100,
-        )
 
 @register_step
 class WriteDataReportPython(BaseStep):

--- a/src/pelagos_py/steps/input_output/write_report_python.py
+++ b/src/pelagos_py/steps/input_output/write_report_python.py
@@ -1082,7 +1082,7 @@ try:
     oxy_stops = sample_cmap(cmocean.cm.oxy)
     chl_stops = sample_cmap(cmocean.cm.algae)
     bbp_stops = sample_cmap(cmocean.cm.turbid)
-except ImportError:
+except Exception:
     temp_stops = ["#1b1c6e", "#365292", "#5286b7", "#8db4c4", "#dbe5cd", "#f1d8b4", "#d9997e", "#c05e4c", "#a0372b", "#811910",]
     sal_stops = ["#f9e8b1", "#f1c38f", "#e8a074", "#db7c5f", "#cb5c58","#b2425c", "#943061", "#732460", "#511c53", "#321340",]
     dens_stops = ["#e6f1f7", "#c4d8e8", "#a6bed9", "#8ba4c9", "#7489b8", "#636c9f","#595388", "#55406e", "#4e3055", "#3f2040", "#2e1226",]
@@ -1236,7 +1236,7 @@ def glider_track_map(data: xr.Dataset, outdir: str, ext: str = ".png") -> str:
 
     proj = ccrs.PlateCarree()
     #   Square figure (1:1) so the map renders proportionally on the title page.
-    fig = plt.figure(figsize=(6, 6))
+    fig = plt.figure(figsize=(6, 6),)
     ax = fig.add_subplot(1, 1, 1, projection=proj)
     fig.patch.set_facecolor(_MAP_OCEAN)
     ax.set_facecolor(_MAP_OCEAN)
@@ -1258,9 +1258,10 @@ def glider_track_map(data: xr.Dataset, outdir: str, ext: str = ".png") -> str:
             break
         except Exception:  # noqa: BLE001 - try the next scale, else skip the basemap
             continue
-
+    
     try:
         gl = ax.gridlines(
+            crs=ccrs.PlateCarree(),
             draw_labels=True, linewidth=0.4, color=_MAP_GRID,
             alpha=0.4, linestyle=":",
         )
@@ -1286,7 +1287,10 @@ def glider_track_map(data: xr.Dataset, outdir: str, ext: str = ".png") -> str:
     #   The track's brightening gold already shows direction of travel (oldest
     #   faint -> newest bright), so no start/end/position marker is drawn.
 
-    fig.tight_layout(pad=0.3)
+    #   fig.tight_layout(pad=x) may not play nice with ax.gridlines(...,draw_labels=True,...)
+    #   for some datasets, erroring out when rendered on plt.savefig.
+    # fig.tight_layout(pad=0.3)
+    fig.subplots_adjust(left=0.10, right=0.97, bottom=0.04, top=0.98)
     fname = outdir + "glider_track" + ext
     plt.savefig(fname, dpi=200, facecolor=fig.get_facecolor())
     plt.close(fig)
@@ -1589,6 +1593,7 @@ def glidertest_section(pdf: ReportPDF, data: xr.Dataset, outdir: str) -> None:
     fig, __ = gtplots.plot_basic_vars(ds=data)
     fig_name = f"{outdir}_basic_vars.png"
     fig.savefig(fig_name)
+    plt.close(fig)
     pdf.image_fit(
         fig_name,
         aspect=_image_aspect(fig_name),
@@ -1602,6 +1607,7 @@ def glidertest_section(pdf: ReportPDF, data: xr.Dataset, outdir: str) -> None:
         fig, __ = gtplots.plot_updown_bias(data, var=var)
         fig_name = f"{outdir}{var}_updown.png"
         fig.savefig(fig_name)
+        plt.close(fig)
         pdf.image_fit(
             fig_name,
             aspect=_image_aspect(fig_name),
@@ -1615,6 +1621,7 @@ def glidertest_section(pdf: ReportPDF, data: xr.Dataset, outdir: str) -> None:
     fig, __ = gtplots.process_optics_assess(ds=data)
     fig_name = f"{outdir}_optics_assess.png"
     fig.savefig(fig_name)
+    plt.close(fig)
     pdf.image_fit(
         fig_name,
         aspect=_image_aspect(fig_name),
@@ -1638,12 +1645,14 @@ def glidertest_section(pdf: ReportPDF, data: xr.Dataset, outdir: str) -> None:
     fig, __ = gtplots.plot_daynight_avg(ds=data, var="CHLA")
     fig_name = f"{outdir}_daynight_avg_sal.png"
     fig.savefig(fig_name)
+    plt.close(fig)
     pdf.image_fit(
         fig_name,
         aspect=_image_aspect(fig_name),
         max_h=100
     )
 
+    #   Summary sheet batch plots (do not export fig, ax)
     pdf.add_page()
     pdf.section_heading("Glidertest Plots: Hysteresis diagnostics")
 
@@ -1910,9 +1919,11 @@ class WriteDataReportPython(BaseStep):
                 cross_section_section(pdf, data, outdir=fig_dir)
 
             if self.parameters.get("show_glidertest", True):
-                self.log("Generating figures from glidertest.")
-                glidertest_section(pdf, data, fig_dir)
-
+                try:
+                    self.log("Generating figures from glidertest.")
+                    glidertest_section(pdf, data, fig_dir)
+                except ImportError as err:
+                    self.log_warn(f"`glidertest` not installed (err: {err}).\nSkipping glidertest figure generation.")
             if (
                 self.parameters.get("show_format_check", True)
                 and "Format Checker" in step_names
@@ -1933,7 +1944,7 @@ class WriteDataReportPython(BaseStep):
                 qc_section(pdf, data)
 
             if self.parameters.get("show_qc_plots", True):
-                self.log("Generating images.")
+                self.log("Generating iterative QC images.")
                 make_plots(pdf, data, outdir=fig_dir)
 
             if self.parameters.get("show_logs", True):

--- a/src/pelagos_py/steps/input_output/write_report_python.py
+++ b/src/pelagos_py/steps/input_output/write_report_python.py
@@ -39,6 +39,7 @@ from fpdf.enums import (
 from fpdf.fonts import FontFace
 from datetime import datetime, timezone
 import getpass
+import glob
 import os
 import platform
 import json
@@ -1568,6 +1569,50 @@ def cross_section_section(pdf: ReportPDF, data: xr.Dataset, outdir: str) -> None
     pdf.image_fit(img, aspect=_image_aspect(img), max_h=avail_h)
 
 
+def glidertest_section(pdf: ReportPDF, data: xr.Dataset, outdir: str) -> None:
+    """
+    Function is in alpha.
+    
+    Runs plotting routines from `glidertest` and inserts them into the document.
+
+    clone glidertest, then install with `pip install -e .` until versioning is sorted out.
+    """
+    from glidertest import summary_sheet as gss
+    from glidertest import plots as gtplots
+
+    pdf.add_page()
+    pdf.section_heading("Glidertest Plots: Hysteresis diagnostics")
+
+    gss.create_hyst_plots(data, path=outdir)
+    for fig_name in sorted(glob.glob(os.path.join(outdir, "*_hyst.png"))):
+        pdf.image_fit(
+            fig_name,
+            aspect=_image_aspect(fig_name),
+            max_h=100,
+        )
+
+    # breakpoint()
+    gss.create_drift_plots(data, path=outdir)
+    for fig_name in sorted(glob.glob(os.path.join(outdir, "*_drift.png"))):
+        pdf.image_fit(
+            fig_name,
+            aspect=_image_aspect(fig_name),
+            max_h=100,
+        )
+
+    path = outdir
+    # breakpoint()
+    for var in ["TEMP", "CNDC", "DOXY"]:
+        fig, ax = gtplots.plot_updown_bias(data, var=var)
+        fig_name = f"{path}/{var}_updown.png"
+        fig.savefig(fig_name)
+        # breakpoint()
+        pdf.image_fit(
+            fig_name,
+            aspect=_image_aspect(fig_name),
+            max_h=100,
+        )
+
 @register_step
 class WriteDataReportPython(BaseStep):
     """
@@ -1719,7 +1764,15 @@ class WriteDataReportPython(BaseStep):
                 "Path to where the organization/institution logo is for use "
                 "on the front page."
             )
+        },
+        "show_glidertest": {
+            "type": bool,
+            "default": False,
+            "description": (
+                "Generate additional figures as done in glidertest's summary sheet."
+            )
         }
+
     }
 
     def run(self) -> xr.DataArray:
@@ -1802,6 +1855,10 @@ class WriteDataReportPython(BaseStep):
             if self.parameters.get("show_cross_section_plots", True):
                 self.log("Generating cross-section plots.")
                 cross_section_section(pdf, data, outdir=fig_dir)
+
+            if self.parameters.get("show_glidertest", True):
+                self.log("Generating figures from glidertest.")
+                glidertest_section(pdf, data, fig_dir)
 
             if (
                 self.parameters.get("show_format_check", True)


### PR DESCRIPTION
Sorry, had issue in 5ae9821c8467256bfe5d61e1c871b943f5d77e49 and a whole bunch of the changes got merged into one commit. Essentially:
* Add `cmocean` for colorbars in profiles, falling back on defined stops if not installed or if there is any kind of error.
* Alphabetize the QC plots (no more will you see "PROFILE_GRADIENT" followed by "LATITUDE" and "CONS_TEMP". Abs. Sal and ADCP will be first now.)
* Add report param `logo`, a path for a user-defined logo. If there isn't one defined, use the NOC default.

Added a check to `pipeline.py` to check user config for the report if they want `_capture_diagnostics` turned on.
* Warrants another check - confirm that this doesn't break anything if not specified (`WriteDataReportPython` default is True).