### PR TITLE
Fix BBP from Beta returning total, not particulate, backscattering

### DIFF
--- a/src/pelagos_py/steps/processing/bbp.py
+++ b/src/pelagos_py/steps/processing/bbp.py
@@ -91,14 +91,26 @@ class BBPFromBeta(BaseStep, QCHandlingMixin):
                 self.data_subset[var], self.data_subset["TIME"]
             )
 
-        # Apply the correction
-        bbp_corrected = gt.flo_functions.flo_bback_total(
-            self.data_subset[self.apply_to],
+        # Apply the correction.
+        #
+        # NOTE: glidertools' flo_bback_total is deliberately NOT used here. It returns
+        # the TOTAL backscattering coefficient (particulate + seawater), because it adds
+        # the seawater backscattering term bsw/2 back in before returning. That is not
+        # what BBP700 is meant to hold: BBP is the PARTICULATE backscattering
+        # coefficient, following the BGC-Argo definition
+        #
+        #     BBP = 2 * pi * chi * (beta(theta) - beta_sw(theta))
+        #
+        # so only the seawater volume scattering function at the measurement angle is
+        # subtracted, and no seawater backscattering is added back.
+        betasw, _bsw = gt.flo_functions.flo_zhang_scatter_coeffs(
             self.data_subset["TEMP"],
             self.data_subset["PRAC_SALINITY"],
             self.theta,
             700,
-            self.xfactor,
+        )
+        bbp_corrected = (
+            self.xfactor * 2.0 * np.pi * (self.data_subset[self.apply_to] - betasw)
         )
 
         # Stitch back into the data

--- a/tests/test_bbp.py
+++ b/tests/test_bbp.py
@@ -1,0 +1,104 @@
+"""Behavioural tests for the 'BBP from Beta' step
+(src/pelagos_py/steps/processing/bbp.py)."""
+
+import numpy as np
+import xarray as xr
+import glidertools as gt
+
+from pelagos_py.steps.processing.bbp import BBPFromBeta
+
+THETA = 124.0
+XFACTOR = 1.076
+WAVELENGTH = 700
+
+
+def make_beta_context(beta, temp=10.0, psal=35.0):
+    """Build a minimal context for BBP from Beta from a 1-D beta array."""
+    beta = np.asarray(beta, dtype=float)
+    n = len(beta)
+    ds = xr.Dataset(
+        {
+            "TIME": (
+                "N_MEASUREMENTS",
+                np.arange(n).astype("datetime64[s]").astype("datetime64[ns]"),
+            ),
+            "PROFILE_NUMBER": ("N_MEASUREMENTS", np.ones(n, dtype=int)),
+            "DEPTH": ("N_MEASUREMENTS", np.linspace(1.0, float(n), n)),
+            "TEMP": ("N_MEASUREMENTS", np.full(n, float(temp))),
+            "PRAC_SALINITY": ("N_MEASUREMENTS", np.full(n, float(psal))),
+            "BETA700": ("N_MEASUREMENTS", beta),
+            "BETA700_QC": ("N_MEASUREMENTS", np.ones(n, dtype=int)),
+        }
+    )
+    return {"data": ds, "global_parameters": {}}
+
+
+def run_step(ctx):
+    step = BBPFromBeta(
+        name="BBP from Beta",
+        parameters={
+            "apply_to": "BETA700",
+            "output_as": "BBP700",
+            "theta": THETA,
+            "xfactor": XFACTOR,
+        },
+        context=ctx,
+    )
+    return step.run()["data"]
+
+
+def test_pure_seawater_beta_gives_zero_bbp():
+    """The headline invariant: water with no particles must give BBP == 0.
+
+    BBP is the PARTICULATE backscattering coefficient. If beta is exactly the
+    theoretical seawater-only volume scattering function, there are no particles,
+    so BBP must be zero. Regression test for the bug where the step returned the
+    TOTAL coefficient (particulate + seawater) because glidertools'
+    flo_bback_total adds the seawater backscattering term bsw/2 back in, which
+    left a spurious offset of ~3.2e-4 m-1 here instead of 0.
+    """
+    temp, psal = 10.0, 35.0
+    betasw, _bsw = gt.flo_functions.flo_zhang_scatter_coeffs(
+        np.array([temp]), np.array([psal]), THETA, WAVELENGTH
+    )
+
+    out = run_step(make_beta_context([betasw[0]] * 3, temp=temp, psal=psal))
+
+    assert np.allclose(out["BBP700"].values, 0.0, atol=1e-12)
+
+
+def test_bbp_matches_the_bgc_argo_definition():
+    """BBP = 2 * pi * chi * (beta - beta_sw), with no seawater term added back."""
+    temp, psal = 10.0, 35.0
+    betasw, _bsw = gt.flo_functions.flo_zhang_scatter_coeffs(
+        np.array([temp]), np.array([psal]), THETA, WAVELENGTH
+    )
+    beta = betasw[0] + np.array([1.0e-5, 5.0e-5, 2.0e-4])
+    expected = XFACTOR * 2.0 * np.pi * (beta - betasw[0])
+
+    out = run_step(make_beta_context(beta, temp=temp, psal=psal))
+
+    assert np.allclose(out["BBP700"].values, expected, rtol=1e-10)
+
+
+def test_no_seawater_backscatter_offset_remains():
+    """Guard the specific regression: output must not be high by bsw/2.
+
+    flo_bback_total returns bbackp + bsw/2. This asserts we are not returning
+    that quantity, which at 700 nm would inflate every value by ~3.2e-4 m-1 --
+    more than the entire particulate signal in deep or oligotrophic water.
+    """
+    temp, psal = 10.0, 35.0
+    betasw, bsw = gt.flo_functions.flo_zhang_scatter_coeffs(
+        np.array([temp]), np.array([psal]), THETA, WAVELENGTH
+    )
+    beta = np.array([betasw[0] + 1.0e-5])
+
+    out = run_step(make_beta_context(beta, temp=temp, psal=psal))
+    total = gt.flo_functions.flo_bback_total(
+        beta, np.array([temp]), np.array([psal]), THETA, WAVELENGTH, XFACTOR
+    )
+
+    # The step must return the particulate coefficient, not the total one.
+    assert not np.allclose(out["BBP700"].values, total)
+    assert np.allclose(out["BBP700"].values, total - bsw[0] / 2, rtol=1e-10)


### PR DESCRIPTION
## Summary

`BBP from Beta` was writing the **total** (particulate + seawater) backscattering
coefficient to `BBP700`, not the particulate coefficient. This PR makes `BBP700` hold
particulate backscattering only, consistent with its name, its documented purpose (a
POC/particle proxy), and the BGC-Argo convention.

## The bug

The step passed beta straight to `glidertools.flo_functions.flo_bback_total`:

```python
bbp_corrected = gt.flo_functions.flo_bback_total(
    self.data_subset[self.apply_to], TEMP, PRAC_SALINITY, self.theta, 700, self.xfactor,
)
```

`flo_bback_total` computes the particulate coefficient and then **adds the seawater
backscattering term back in** before returning (its own docstring: `bback = total
(seawater + particulate) optical backscatter coefficient`):

```python
bbackp = xfactor * 2.0 * pi * betap   # particulate backscattering (this is b_bp)
bbsw   = bsw / 2                      # seawater backscattering
bback  = bbackp + bbsw                # total (particulates + seawater)
return bback
```

Nothing downstream removed it, so `BBP700` = b_bb, not b_bp.

## Impact

The added term is a near-constant offset of **b_bsw(700) ≈ 3.19e-4 m⁻¹** (3.11e-4 to
3.29e-4 over T = 2-28°C, S = 34.7-35), which is negligible relative to the particulate
signal in a bloom but dominates it in the clear water where BBP is used hardest:

| Regime                | true b_bp | old `BBP700` | overestimate |
|------------------------|-----------|---------------|---------------|
| Deep ocean (>1000 m)  | 5.0e-05   | 3.69e-04      | +639%         |
| Oligotrophic surface  | 3.0e-04   | 6.19e-04      | +106%         |
| Temperate surface     | 1.0e-03   | 1.32e-03      | +32%          |
| Spring bloom          | 4.0e-03   | 4.32e-03      | +8%           |

Downstream effects of the old behaviour:
- POC proxies biased high, worst where the particulate signal is smallest.
- Vertical profile shape distorted (inflated deep background flattens real gradients).
- The backscatter-based chlorophyll NPQ corrections use a chla/BBP **ratio** — a
  constant additive offset in the denominator distorts the correction, worst in clear
  water.
- `BBP700_SPIKES` (from `Isolate BBP Spikes`) is unaffected, since a constant offset
  cancels in `measurement - baseline`; `BBP700_BASELINE` is not.

## The fix

Compute particulate backscattering directly, following the BGC-Argo definition
(Schmechtig et al., BGC-Argo BBP processing):

```
BBP = 2 * pi * chi * (beta(theta) - beta_sw(theta))
```

using the public `flo_zhang_scatter_coeffs` for the seawater term, so only the
seawater volume scattering function at the measurement angle is subtracted — no
seawater backscattering is added back.

## Tests

Added `tests/test_bbp.py::test_pure_seawater_beta_gives_zero_bbp` (the headline
invariant: particle-free water must give BBP ≈ 0), plus a definition check and an
explicit guard against reintroducing the `bsw/2` offset. All three fail against the
pre-fix implementation and pass after. Full suite: 141 passed, no regressions.

## Breaking change

This changes numerical output. Data already processed with `BBP from Beta` will need
reprocessing to be comparable with data processed after this fix.

## Deliberately out of scope (flagged for a follow-up, not fixed here)

- **Wavelength is hard-coded to 700 nm** in the call, independent of `apply_to`/
  `output_as`. b_bsw is strongly wavelength-dependent (1.69e-3 at 470 nm, 1.00e-3 at
  532 nm, 3.19e-4 at 700 nm), so deriving e.g. `BBP532` today uses the wrong seawater
  term on top of this bug. This fix corrects the particulate/total distinction but does
  not plumb through a configurable wavelength — that's a separate, larger change.
- **Whether a total-backscattering product is also wanted** (e.g. for reflectance/
  ocean-colour work) as a distinctly-named output such as `BB700`, rather than under
  the `BBP*` name. Happy to add that in this PR or a follow-up if there's demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
